### PR TITLE
Feature/#31 find user id&pw

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: '2.3.1.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/flab/resellPlatform/SecurityConfig.java
+++ b/src/main/java/flab/resellPlatform/SecurityConfig.java
@@ -1,11 +1,13 @@
 package flab.resellPlatform;
 
+import org.apache.commons.text.RandomStringGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -22,5 +24,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public RandomValueStringGenerator randomValueStringGenerator() {
+        return new RandomValueStringGenerator();
     }
 }

--- a/src/main/java/flab/resellPlatform/SecurityConfig.java
+++ b/src/main/java/flab/resellPlatform/SecurityConfig.java
@@ -1,6 +1,5 @@
 package flab.resellPlatform;
 
-import org.apache.commons.text.RandomStringGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;

--- a/src/main/java/flab/resellPlatform/common/utils/UserUtils.java
+++ b/src/main/java/flab/resellPlatform/common/utils/UserUtils.java
@@ -1,0 +1,7 @@
+package flab.resellPlatform.common.utils;
+
+public final class UserUtils {
+    public static final String normalizePhoneNumber(String phoneNumber) {
+        return phoneNumber.replaceAll("[-]", "");
+    }
+}

--- a/src/main/java/flab/resellPlatform/controller/user/HomeController.java
+++ b/src/main/java/flab/resellPlatform/controller/user/HomeController.java
@@ -30,12 +30,12 @@ public class HomeController {
                 .data(Map.of());
 
         if (session == null) {
-            return getStandardResponseEntity(standardResponseBuilder, "common.login.need", HttpStatus.UNAUTHORIZED);
+            return getStandardResponseEntity(standardResponseBuilder, "common.login.needed", HttpStatus.UNAUTHORIZED);
         }
 
         LoginInfo loginInfo = (LoginInfo) session.getAttribute(SessionConst.LOGIN_INFO);
         if (loginInfo == null) {
-            return getStandardResponseEntity(standardResponseBuilder, "common.login.need", HttpStatus.UNAUTHORIZED);
+            return getStandardResponseEntity(standardResponseBuilder, "common.login.needed", HttpStatus.UNAUTHORIZED);
         }
 
         return getStandardResponseEntity(standardResponseBuilder, "home.welcome", HttpStatus.OK);

--- a/src/main/java/flab/resellPlatform/controller/user/UserController.java
+++ b/src/main/java/flab/resellPlatform/controller/user/UserController.java
@@ -37,11 +37,9 @@ public class UserController {
         user.setPassword(passwordEncoder.encode(user.getPassword()));
         Optional<UserDTO> joinedInfo = userService.createUser(user);
 
-        Map<String, Object> returnObjects = Map.of("user", joinedInfo.get());
-
         StandardResponse defaultResponse = StandardResponse.builder()
                 .message(messageSourceAccessor.getMessage("user.join.succeeded"))
-                .data(returnObjects)
+                .data(Map.of())
                 .build();
 
         return ResponseEntity

--- a/src/main/java/flab/resellPlatform/controller/user/UserController.java
+++ b/src/main/java/flab/resellPlatform/controller/user/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
     }
 
     @GetMapping("/usernameInquiry")
-    public ResponseEntity inquireUsername(String phoneNumber) {
+    public ResponseEntity findUsername(String phoneNumber) {
         Optional<String> result = userService.findUsername(phoneNumber);
         if (result.isEmpty()) {
             throw new PhoneNumberNotFoundException();
@@ -63,7 +63,7 @@ public class UserController {
     }
 
     @PostMapping("/password/inquiry")
-    public ResponseEntity inquirePassword(StrictLoginInfo strictLoginInfo) {
+    public ResponseEntity findPassword(StrictLoginInfo strictLoginInfo) {
 
         // 임시 비밀번호 생성 
         String randomGeneratedPassword = randomValueStringGenerator.generate();
@@ -93,7 +93,10 @@ public class UserController {
         String encodedPassword = passwordEncoder.encode(newLoginInfo.getPassword());
         newLoginInfo.setPassword(encodedPassword);
 
-        userService.updatePassword(newLoginInfo);
+        int result = userService.updatePassword(newLoginInfo);
+        if (result == 0) {
+            throw new UserInfoNotFoundException();
+        }
 
         StandardResponse response = StandardResponse.builder()
                 .message(messageSourceAccessor.getMessage("user.password.updated.succeeded"))

--- a/src/main/java/flab/resellPlatform/domain/user/StrictLoginInfo.java
+++ b/src/main/java/flab/resellPlatform/domain/user/StrictLoginInfo.java
@@ -1,15 +1,23 @@
 package flab.resellPlatform.domain.user;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 
 @Builder
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class StrictLoginInfo {
+    @NotBlank
     private String username;
+    @NotBlank
     private String password;
+    @NotBlank
     private String phoneNumber;
+    @NotBlank
+    @Email
     private String email;
 }

--- a/src/main/java/flab/resellPlatform/domain/user/StrictLoginInfo.java
+++ b/src/main/java/flab/resellPlatform/domain/user/StrictLoginInfo.java
@@ -1,12 +1,15 @@
 package flab.resellPlatform.domain.user;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+@Builder
 @Getter
 @Setter
-public class PasswordInquiryForm {
+public class StrictLoginInfo {
     private String username;
+    private String password;
     private String phoneNumber;
     private String email;
 }

--- a/src/main/java/flab/resellPlatform/repository/user/MybatisUserRepository.java
+++ b/src/main/java/flab/resellPlatform/repository/user/MybatisUserRepository.java
@@ -1,6 +1,8 @@
 package flab.resellPlatform.repository.user;
 
+import flab.resellPlatform.domain.user.LoginInfo;
 import flab.resellPlatform.domain.user.PasswordInquiryForm;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,8 +28,28 @@ public class MybatisUserRepository implements UserRepository {
     }
 
     @Override
+    public Optional<String> findUsername(String phoneNumber) {
+        return userMapper.findUsername(phoneNumber);
+    }
+
+    @Override
+    public Optional<LoginInfo> findRequiredInfoForLogin(PasswordInquiryForm inquiryData) {
+        return userMapper.findRequiredInfoForLogin(inquiryData);
+    }
+
+    @Override
     public List<UserEntity> findAll() {
         return userMapper.findAll();
+    }
+
+    @Override
+    public int updatePassword(LoginInfo loginInfo) {
+        return userMapper.updatePassword(loginInfo);
+    }
+
+    @Override
+    public int updatePassword(StrictLoginInfo strictLoginInfo) {
+        return userMapper.updatePasswordSecurely(strictLoginInfo);
     }
 
 }

--- a/src/main/java/flab/resellPlatform/repository/user/MybatisUserRepository.java
+++ b/src/main/java/flab/resellPlatform/repository/user/MybatisUserRepository.java
@@ -33,11 +33,6 @@ public class MybatisUserRepository implements UserRepository {
     }
 
     @Override
-    public Optional<LoginInfo> findRequiredInfoForLogin(PasswordInquiryForm inquiryData) {
-        return userMapper.findRequiredInfoForLogin(inquiryData);
-    }
-
-    @Override
     public List<UserEntity> findAll() {
         return userMapper.findAll();
     }

--- a/src/main/java/flab/resellPlatform/repository/user/UserMapper.java
+++ b/src/main/java/flab/resellPlatform/repository/user/UserMapper.java
@@ -1,6 +1,8 @@
 package flab.resellPlatform.repository.user;
 
+import flab.resellPlatform.domain.user.LoginInfo;
 import flab.resellPlatform.domain.user.PasswordInquiryForm;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserEntity;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -13,4 +15,8 @@ public interface UserMapper {
     Optional<UserEntity> findByUsername(String username);
     List<UserEntity> findAll();
     int getUsernameCount(String username);
+    Optional<String> findUsername(String phoneNumber);
+    Optional<LoginInfo> findRequiredInfoForLogin(PasswordInquiryForm inquiryData);
+    int updatePassword(LoginInfo loginInfo);
+    int updatePasswordSecurely(StrictLoginInfo strictLoginInfo);
 }

--- a/src/main/java/flab/resellPlatform/repository/user/UserRepository.java
+++ b/src/main/java/flab/resellPlatform/repository/user/UserRepository.java
@@ -12,7 +12,6 @@ public interface UserRepository {
     UserEntity save(UserEntity userEntity);
     Optional<UserEntity> findUser(String username);
     Optional<String> findUsername(String phoneNumber);
-    Optional<LoginInfo> findRequiredInfoForLogin(PasswordInquiryForm inquiryData);
     List<UserEntity> findAll();
     int updatePassword(LoginInfo loginInfo);
 

--- a/src/main/java/flab/resellPlatform/repository/user/UserRepository.java
+++ b/src/main/java/flab/resellPlatform/repository/user/UserRepository.java
@@ -1,6 +1,8 @@
 package flab.resellPlatform.repository.user;
 
+import flab.resellPlatform.domain.user.LoginInfo;
 import flab.resellPlatform.domain.user.PasswordInquiryForm;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserEntity;
 
 import java.util.List;
@@ -9,5 +11,10 @@ import java.util.Optional;
 public interface UserRepository {
     UserEntity save(UserEntity userEntity);
     Optional<UserEntity> findUser(String username);
+    Optional<String> findUsername(String phoneNumber);
+    Optional<LoginInfo> findRequiredInfoForLogin(PasswordInquiryForm inquiryData);
     List<UserEntity> findAll();
+    int updatePassword(LoginInfo loginInfo);
+
+    int updatePassword(StrictLoginInfo strictLoginInfo);
 }

--- a/src/main/java/flab/resellPlatform/service/user/UserService.java
+++ b/src/main/java/flab/resellPlatform/service/user/UserService.java
@@ -1,10 +1,60 @@
 package flab.resellPlatform.service.user;
 
+import flab.resellPlatform.domain.user.LoginInfo;
 import flab.resellPlatform.domain.user.PasswordInquiryForm;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserDTO;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Optional;
 
 public interface UserService {
+
+    /**
+    * 회원가입
+    *
+    * @param userInfo 회원가입에 필요한 정보
+    * @return Optional UserDTO.
+    * @exception SQLIntegrityConstraintViolationException Unique 정보가 이미 존재함.
+    *
+    * @작성일 6/19/2022
+    * @작성자 minsuk
+    */
     Optional<UserDTO> createUser(UserDTO userInfo);
+
+    /**
+    * 사용자 아이디 찾기
+    *
+    * @param phoneNumber 핸드폰 번호
+    * @return Optional String. param으로 username을 찾지 못하면 Optional.empty() 반환.
+    * @exception 
+    *
+    * @작성일 6/19/2022
+    * @작성자 minsuk
+    */
+    Optional<String> findUsername(String phoneNumber);
+
+    /**
+    * 아이디와 비밀번호로 비밀번호를 변경함.
+    *
+    * @param loginInfo 로그인에 필요한 정보.
+    * @return int 성공시 1보다 같거나 큰 값 반환, 실패시 0 반환.
+    * @exception
+    *
+    * @작성일 6/19/2022
+    * @작성자 minsuk
+    */
+    int updatePassword(LoginInfo loginInfo);
+
+    /**
+     * 아이디 비밀번호 외에 사용자를 검증할 수 있는 추가적인 데이터들을 이용하여 비밀번호를 변경함.
+     *
+     * @param strictLoginInfo 비밀번호 찾기에 필요한 정보.
+     * @return int 성공시 1보다 같거나 큰 값 반환, 실패시 0 반환.
+     * @exception
+     *
+     * @작성일 6/19/2022
+     * @작성자 minsuk
+     */
+    int updatePassword(StrictLoginInfo strictLoginInfo);
 }

--- a/src/main/java/flab/resellPlatform/service/user/UserServiceImpl.java
+++ b/src/main/java/flab/resellPlatform/service/user/UserServiceImpl.java
@@ -1,11 +1,13 @@
 package flab.resellPlatform.service.user;
 
-import flab.resellPlatform.domain.user.PasswordInquiryForm;
-import flab.resellPlatform.domain.user.UserDTO;
-import flab.resellPlatform.domain.user.UserEntity;
+import flab.resellPlatform.domain.user.*;
 import flab.resellPlatform.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -22,5 +24,20 @@ public class UserServiceImpl implements UserService{
         UserEntity userEntity = modelMapper.map(userInfo, UserEntity.class);
         userRepository.save(userEntity);
         return Optional.of(userInfo);
+    }
+
+    @Override
+    public Optional<String> findUsername(String phoneNumber) {
+        return userRepository.findUsername(phoneNumber);
+    }
+
+    @Override
+    public int updatePassword(LoginInfo loginInfo) {
+        return userRepository.updatePassword(loginInfo);
+    }
+
+    @Override
+    public int updatePassword(StrictLoginInfo strictLoginInfo) {
+        return userRepository.updatePassword(strictLoginInfo);
     }
 }

--- a/src/main/resources/flab/resellPlatform/properties/messages/en_US.properties
+++ b/src/main/resources/flab/resellPlatform/properties/messages/en_US.properties
@@ -1,20 +1,21 @@
 # common
 common.argument.invalid=Please provide valid data
-common.login.need=Please login first
+common.login.needed=Please login first
 
 # userController
 user.username.duplicated=Duplicate username exists
-user.join.succeeded=User join succeed
+user.join.succeeded=User join succeeded
 user.phoneNumber.notFound=There isn't id which matches the phone number
 user.username.found=Found the username
-user.password.found=Found the password
+user.temporary.password.returned=User temporary password update succeeded
 user.userInfo.notFound=There isn't user information which matches the input
+user.password.updated.succeeded=User password update succeeded
 
 # homeController
 home.welcome=Welcome
 
 # loginController
-login.succeeded=User login succeed
-login.logout.succeeded=User logout succeed
+login.succeeded=User login succeeded
+login.logout.succeeded=User logout succeeded
 
 

--- a/src/main/resources/flab/resellPlatform/repository/user/UserMapper.xml
+++ b/src/main/resources/flab/resellPlatform/repository/user/UserMapper.xml
@@ -31,12 +31,6 @@
         where phoneNumber = #{phoneNumber}
     </select>
 
-    <select id="findRequiredInfoForLogin" resultType="LoginInfo">
-        select username, password
-        from user
-        where phoneNumber = #{phoneNumber} and email = #{email}
-    </select>
-
     <update id="updatePassword">
         update user
         set password = #{password}

--- a/src/main/resources/flab/resellPlatform/repository/user/UserMapper.xml
+++ b/src/main/resources/flab/resellPlatform/repository/user/UserMapper.xml
@@ -25,4 +25,27 @@
         where username = #{username}
     </select>
 
+    <select id="findUsername" resultType="String">
+        select username
+        from user
+        where phoneNumber = #{phoneNumber}
+    </select>
+
+    <select id="findRequiredInfoForLogin" resultType="LoginInfo">
+        select username, password
+        from user
+        where phoneNumber = #{phoneNumber} and email = #{email}
+    </select>
+
+    <update id="updatePassword">
+        update user
+        set password = #{password}
+        where username = #{username}
+    </update>
+
+    <update id="updatePasswordSecurely">
+        update user
+        set password = #{password}
+        where username = #{username} and phoneNumber = #{phoneNumber} and email = #{email}
+    </update>
 </mapper>

--- a/src/test/java/flab/resellPlatform/controller/user/UserControllerTest.java
+++ b/src/test/java/flab/resellPlatform/controller/user/UserControllerTest.java
@@ -3,6 +3,7 @@ package flab.resellPlatform.controller.user;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import flab.resellPlatform.MessageConfig;
+import flab.resellPlatform.common.utils.UserUtils;
 import flab.resellPlatform.controller.response.StandardResponse;
 import flab.resellPlatform.data.UserTestFactory;
 import flab.resellPlatform.domain.user.LoginInfo;
@@ -133,8 +134,9 @@ class UserControllerTest {
         // given
         String targetUsername = "michael";
         String requiredPhoneNumber = "010-4589-0000";
+        String normalizedPhoneNumber = UserUtils.normalizePhoneNumber(requiredPhoneNumber);
         String query = "phoneNumber=" + requiredPhoneNumber;
-        when(userService.findUsername(requiredPhoneNumber)).thenReturn(Optional.of(targetUsername));
+        when(userService.findUsername(normalizedPhoneNumber)).thenReturn(Optional.of(targetUsername));
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/users/usernameInquiry" + "?" + query)

--- a/src/test/java/flab/resellPlatform/controller/user/UserControllerTest.java
+++ b/src/test/java/flab/resellPlatform/controller/user/UserControllerTest.java
@@ -1,9 +1,12 @@
 package flab.resellPlatform.controller.user;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import flab.resellPlatform.MessageConfig;
 import flab.resellPlatform.controller.response.StandardResponse;
 import flab.resellPlatform.data.UserTestFactory;
+import flab.resellPlatform.domain.user.LoginInfo;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserDTO;
 import flab.resellPlatform.service.user.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Map;
@@ -26,6 +33,7 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,7 +49,15 @@ class UserControllerTest {
     MockMvc mockMvc;
 
     @MockBean
+    RandomValueStringGenerator randomValueStringGenerator;
+
+    @MockBean
+    PasswordEncoder passwordEncoder;
+
+    @MockBean
     UserService userService;
+
+    ObjectMapper mapper = new ObjectMapper();
 
     @DisplayName("아이디 생성 성공")
     @Test
@@ -49,7 +65,6 @@ class UserControllerTest {
         // given
         UserDTO userDTO = UserTestFactory.createUserDTOBuilder().build();
         when(userService.createUser(any())).thenReturn(Optional.of(userDTO));
-        ObjectMapper mapper = new ObjectMapper();
         String userData = mapper.writeValueAsString(userDTO);
 
         // when
@@ -68,7 +83,6 @@ class UserControllerTest {
         UserDTO userDTO = UserTestFactory.createUserDTOBuilder()
                 .email("alstjrdl852naver.com")
                 .build();
-        ObjectMapper mapper = new ObjectMapper();
         String userData = mapper.writeValueAsString(userDTO);
 
         // when
@@ -83,7 +97,7 @@ class UserControllerTest {
                 .data(returnObjects)
                 .build();
 
-        expectDefaultResponse(mapper, defaultResponse, resultActions);
+        expectDefaultResponse(defaultResponse, status().isBadRequest(), resultActions);
     }
 
     @DisplayName("아이디 생성 실패 by 아이디 중복")
@@ -96,7 +110,6 @@ class UserControllerTest {
                 throw new SQLIntegrityConstraintViolationException();
             }
         });
-        ObjectMapper mapper = new ObjectMapper();
         String userData = mapper.writeValueAsString(userDTO);
 
         // when
@@ -111,13 +124,156 @@ class UserControllerTest {
                 .message(messageSourceAccessor.getMessage("user.username.duplicated"))
                 .data(returnObjects)
                 .build();
-        expectDefaultResponse(mapper, defaultResponse, resultActions);
+        expectDefaultResponse(defaultResponse, status().isBadRequest(), resultActions);
     }
 
-    private void expectDefaultResponse(ObjectMapper mapper, StandardResponse standardResponse, ResultActions resultActions) throws Exception {
+    @DisplayName("아이디 찾기 성공")
+    @Test
+    void findUsername_found() throws Exception {
+        // given
+        String targetUsername = "michael";
+        String requiredPhoneNumber = "010-4589-0000";
+        String query = "phoneNumber=" + requiredPhoneNumber;
+        when(userService.findUsername(requiredPhoneNumber)).thenReturn(Optional.of(targetUsername));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/users/usernameInquiry" + "?" + query)
+                .with(csrf()));
+
+        // then
+        StandardResponse standardResponse = StandardResponse.builder()
+                .message(messageSourceAccessor.getMessage("user.username.found"))
+                .data(Map.of("username", targetUsername))
+                .build();
+
+        expectDefaultResponse(standardResponse, status().isOk(), resultActions);
+    }
+
+    @DisplayName("아이디 찾기 실패")
+    @Test
+    void findUsername_phoneNumberNotFound() throws Exception {
+        // given
+        String targetUsername = "michael";
+        String requiredPhoneNumber = "010-4589-0000";
+        String query = "phoneNumber=" + requiredPhoneNumber;
+        when(userService.findUsername(requiredPhoneNumber)).thenReturn(Optional.empty());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/users/usernameInquiry" + "?" + query)
+                .with(csrf()));
+
+        // then
+        ObjectMapper mapper = new ObjectMapper();
+        StandardResponse standardResponse = StandardResponse.builder()
+                .message(messageSourceAccessor.getMessage("user.phoneNumber.notFound"))
+                .data(Map.of())
+                .build();
+
+        expectDefaultResponse(standardResponse, status().isBadRequest(), resultActions);
+    }
+
+    @DisplayName("비밀번호 찾기 성공 by 임시 비밀번호 발급")
+    @Test
+    void findPassword_success() throws Exception {
+        // given
+        StrictLoginInfo strictLoginInfo = UserTestFactory.createStrictLoginInfoBuilder().build();
+        String body = mapper.writeValueAsString(strictLoginInfo);
+        String temporaryPassword = "fslkkjlk12";
+        when(randomValueStringGenerator.generate()).thenReturn(temporaryPassword);
+        when(userService.updatePassword((StrictLoginInfo) any())).thenReturn(1);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/users/password/inquiry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf()));
+
+        // then
+        StandardResponse standardResponse = StandardResponse.builder()
+                .data(Map.of("password", temporaryPassword))
+                .message(messageSourceAccessor.getMessage("user.temporary.password.returned"))
+                .build();
+        expectDefaultResponse(standardResponse, status().isOk(), resultActions);
+
+    }
+
+    @DisplayName("비밀번호 찾기 실패 by 유저 정보 불일치")
+    @Test
+    void findPassword_failure() throws Exception {
+        // given
+        StrictLoginInfo strictLoginInfo = UserTestFactory.createStrictLoginInfoBuilder().build();
+        String body = mapper.writeValueAsString(strictLoginInfo);
+        String temporaryPassword = "fslkkjlk12";
+        when(randomValueStringGenerator.generate()).thenReturn(temporaryPassword);
+        when(userService.updatePassword(strictLoginInfo)).thenReturn(0);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/users/password/inquiry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf()));
+
+        // then
+        StandardResponse standardResponse = StandardResponse.builder()
+                .data(Map.of())
+                .message(messageSourceAccessor.getMessage("user.userInfo.notFound"))
+                .build();
+        expectDefaultResponse(standardResponse, status().isBadRequest(), resultActions);
+
+    }
+
+    @DisplayName("패스워드 업데이트 성공")
+    @Test
+    void updatePassword_success() throws Exception {
+        // given
+        LoginInfo loginInfo = UserTestFactory.createLoginInfoBuilder().build();
+        String body = mapper.writeValueAsString(loginInfo);
+        when(passwordEncoder.encode(any())).thenReturn("encodedPW");
+        when(userService.updatePassword((LoginInfo) any())).thenReturn(1);
+
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/users/password/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf()));
+
+        // then
+        StandardResponse standardResponse = StandardResponse.builder()
+                .message(messageSourceAccessor.getMessage("user.password.updated.succeeded"))
+                .data(Map.of())
+                .build();
+        expectDefaultResponse(standardResponse, status().isOk(), resultActions);
+    }
+
+    @DisplayName("패스워드 업데이트 실패")
+    @Test
+    void updatePassword_failure() throws Exception {
+        // given
+        LoginInfo loginInfo = UserTestFactory.createLoginInfoBuilder().build();
+        String body = mapper.writeValueAsString(loginInfo);
+        when(passwordEncoder.encode(any())).thenReturn("encodedPW");
+        when(userService.updatePassword((LoginInfo) any())).thenReturn(0);
+
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/users/password/update")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .with(csrf()));
+
+        // then
+        StandardResponse standardResponse = StandardResponse.builder()
+                .message(messageSourceAccessor.getMessage("user.userInfo.notFound"))
+                .data(Map.of())
+                .build();
+        expectDefaultResponse(standardResponse, status().isBadRequest(), resultActions);
+    }
+    
+    private void expectDefaultResponse(StandardResponse standardResponse, ResultMatcher status, ResultActions resultActions) throws Exception {
         String defaultResponseJson = mapper.writeValueAsString(standardResponse);
         resultActions
-                .andExpect(status().isBadRequest())
+                .andExpect(status)
                 .andExpect(content().string(defaultResponseJson));
     }
 }

--- a/src/test/java/flab/resellPlatform/data/UserTestFactory.java
+++ b/src/test/java/flab/resellPlatform/data/UserTestFactory.java
@@ -14,7 +14,7 @@ public class UserTestFactory {
     public static final String DEFAULT_NICKNAME = "uj";
     public static final String DEFAULT_EMAIL = "a@a.com";
     public static final String DEFAULT_NAME = "ms";
-    public static final String DEFAULT_PHONE_NUMBER = "010-3333-1250";
+    public static final String DEFAULT_PHONE_NUMBER = "01033331250";
     public static final String DEFAULT_SHOE_SIZE = "275";
 
     public static UserDTO.UserDTOBuilder createUserDTOBuilder () {

--- a/src/test/java/flab/resellPlatform/data/UserTestFactory.java
+++ b/src/test/java/flab/resellPlatform/data/UserTestFactory.java
@@ -1,6 +1,7 @@
 package flab.resellPlatform.data;
 
 import flab.resellPlatform.domain.user.LoginInfo;
+import flab.resellPlatform.domain.user.StrictLoginInfo;
 import flab.resellPlatform.domain.user.UserDTO;
 import flab.resellPlatform.domain.user.UserEntity;
 
@@ -9,7 +10,7 @@ public class UserTestFactory {
     private UserTestFactory() {}
 
     public static final String DEFAULT_USERNAME = "minsuk";
-    public static final String DEFAULT_PW = "a";
+    public static final String DEFAULT_PW = "123";
     public static final String DEFAULT_NICKNAME = "uj";
     public static final String DEFAULT_EMAIL = "a@a.com";
     public static final String DEFAULT_NAME = "ms";
@@ -42,5 +43,13 @@ public class UserTestFactory {
         return LoginInfo.builder()
                 .username(DEFAULT_USERNAME)
                 .password(DEFAULT_PW);
+    }
+
+    static public StrictLoginInfo.StrictLoginInfoBuilder createStrictLoginInfoBuilder() {
+        return StrictLoginInfo.builder()
+                .username(DEFAULT_USERNAME)
+                .password(DEFAULT_PW)
+                .phoneNumber(DEFAULT_PHONE_NUMBER)
+                .email(DEFAULT_EMAIL);
     }
 }


### PR DESCRIPTION
pr과 직접적으로 연관된 커밋은 feature/아이디 찾기, 비밀번호 찾기 구현' 하나이기 때문에 해당 커밋의 설명을 그대로 참조했습니다.

1. 아이디 찾기
- 핸드폰 번호를 이용하여 아이디 찾기 기능을 구현했습니다. 해당 함수의 파라미터를 UsernameFindForm으로 추상화하여 미래 아이디 찾기 알고리즘 변경에 대비할 수 있지만, 핸드폰 번호는 unique한 값이기 때문에 알고리즘 변경이 없을 것으로 판단했습니다.

2. 비밀번호 찾기 구현
- 비밀번호는 모두 컨트롤러에서 encoding합니다. 추후 spring security를 적극 도입할 시 로그인 기능을 유연하게 이전할 수 있기 때문입니다.
- 비밀번호 찾기는 새로운 임시 비밀번호를 발급 받는 방향으로 구현했습니다. 해시 함수로 encode된 비밀번호를 저장하기 때문에 비밀번호를 찾을 수 없기 때문입니다. 즉 사용자 데이터의 보안성을 높이기 위해 UX와 trade off 했습니다. 그렇지만 사용자는 안전한 서비스를 사용할 수 있기 때문에 전체 UX는 높아집니다.
- 비밀번호 업데이트 함수는 두개가 존재합니다. 매개변수로 StrictLoginInfo를 가지는 함수는 임시 비밀번호 발급 용이고 매개변수로 LoginInfo를 가지는 함수는 로그인 후에 비밀번호 변경 용입니다. 로그인 후 비밀번호 변경 용 함수는 추후 Spring security를 이용한 사용자별 권한 도입 시, 사용 권한을 추가로 부여할 예정입니다.