### PR TITLE
CI 적용

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      with:
+        arguments: build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,6 +28,8 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
+    - name: Run chmod to make gradlew executable
+      run: chmod +x ./gradlew
     - name: Build with Gradle
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:


### PR DESCRIPTION
### 목적
CI 테스트

### 구현 사항
1. Github action에서 제공하는 'Java with gradle'을 그대로 사용

### 근거
- [actions/virtual-enviroments](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#tools)에 따르면 우분투 최신 버전(2004 기준)에는 docker와 docker compose가 설치돼있음. resell-platform 플랫폼 프로젝트는 도커 환경과 자바만 깔려 있으면 빌드 될 수 있음. 따라서 본 CI는 통과해야함.